### PR TITLE
feat: improve article pagination

### DIFF
--- a/src/app/page/[no]/page.tsx
+++ b/src/app/page/[no]/page.tsx
@@ -3,11 +3,11 @@ import { HomeASides } from 'components/ASides';
 import { HomeRightSide } from 'components/RightSide';
 import { notFound } from 'next/navigation';
 
-export default function Page({ params }: { params: { no: number } }) {
+export default function Page({ params }: { params: { no: string } }) {
     try {
         return (
             <div id="main-container">
-                <Posts page={params.no} />
+                <Posts page={parseInt(params.no)} />
                 <HomeASides />
                 <HomeRightSide />
             </div>

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -12,7 +12,8 @@ export const siteConfigs: SiteConfig = {
     createYear: 2022,
     createMonth: 6,
     createDay: 4,
-    pageMaxPosts: 15,
+    homeMaxPosts: 15,
+    pageMaxPosts: 16,
     falldownAvatar: "https://img.0v0.my/2024/09/06/66dabf7f748c8.jpg",
     falldownImg: "https://img.0v0.my/2024/08/31/66d30329375a5.webp",
     backEndUrl: (() => {
@@ -175,4 +176,3 @@ export const FooterBadges: FooterBadge[] = [
         link: "https://www.travellings.cn/"
     },
 ]
-

--- a/src/interfaces/siteconfig.d.ts
+++ b/src/interfaces/siteconfig.d.ts
@@ -10,6 +10,7 @@ export declare interface SiteConfig {
     createMonth: number,
     twikooEnv: string,
     siteUrl: string,
+    homeMaxPosts: number,
     pageMaxPosts: number,
     backEndUrl: string,
     falldownAvatar: string,

--- a/src/styles/PostCard.css
+++ b/src/styles/PostCard.css
@@ -313,7 +313,8 @@
 
 .post-card-pgwrap {
     margin: 10px 20px;
-    flex: 1;
+    flex: 100%;
+    text-align: center;
 }
 
 .post-card-pgbtn:hover,


### PR DESCRIPTION
## 功能：改进文章翻页
ww 咱发现，博客的文章翻页有点奇怪喵，只能翻到第二页。
于是尝试修复了一下，顺便加了点新功能。

主要是新增了个 `homeMaxPosts` 配置项，可以单独设置首页的分页数。
这样后面的分页 (除了最后一页)，就不会因为单数缺一个啦！\\^o^/

还调整了下翻页按钮的位置，不过这个主要看**个人喜好**。
(=・ω・=) 不太合心意的话，可以改掉。

![AriaBlogNext 翻页](https://github.com/user-attachments/assets/9bf3e851-8ac9-4c3f-aa90-84e2542bcd1c)
![AriaBlogNext 新版翻页](https://github.com/user-attachments/assets/4d89672a-0c58-4b5a-8836-b9d3c5c7056d)
![AriaBlogNext 新版翻页 末页](https://github.com/user-attachments/assets/7bafe466-9e73-4e71-8e41-32db673235ca)